### PR TITLE
Update Acxiom information

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,15 @@ Google further allows you to remove non-consensual or intimate personal images, 
 
 It is hard to find your own info for free, but people in some countries can opt out using the following links:
 
-[https://gdpr-fr.eu.acxiom.com/](https://gdpr-fr.eu.acxiom.com/) [https://www.acxiom.com/privacy/fr/](https://www.acxiom.com/privacy/fr/) (France)
-
-[https://www.acxiom.com/privacy/datenschutz/](https://www.acxiom.com/privacy/datenschutz/) (Germany)
+[https://www.acxiom.com/privacy/fr/](https://www.acxiom.com/privacy/fr/) (France)
 
 [https://www.acxiom.com/privacy/it/](https://www.acxiom.com/privacy/it/) (Italy)
 
 [https://www.acxiom.com/privacy/es/](https://www.acxiom.com/privacy/es/) (Spain)
 
-[https://isapps.acxiom.com/optout/](https://isapps.acxiom.com/optout/) (U.S.)
+[https://www.acxiom.com/optout/](https://www.acxiom.com/optout/) (U.S.)
 
-Users in Austria, India and Switzerland may email [Datenschutz@acxiom.com](mailto:Datenschutz@acxiom.com).
+Users in Austria, India, Germany and Switzerland may email [datenschutz@acxiom.com](mailto:datenschutz@acxiom.com).
 
 Other international requests should click on [https://privacyportal.onetrust.com/webform/342ca6ac-4177-4827-b61e-19070296cbd3/6896cf25-6953-4500-9c69-5a8fb6f6f932](https://privacyportal.onetrust.com/webform/342ca6ac-4177-4827-b61e-19070296cbd3/6896cf25-6953-4500-9c69-5a8fb6f6f932) 
 


### PR DESCRIPTION
The first French link ("https://gdpr-fr.eu.acxiom.com/") seems to be a dead link and the German link ("https://www.acxiom.com/privacy/datenschutz/") is an official Acxiom page in German indicating two opt-out methods: sending an email to datenschutz@acxiom.com or submitting an opt-out form with the link "http://www.acxiom.de/verbraucheranfragen/", that redirects to this webpage "https://www.acxiom.de/datenschutzanfragen/", which only shows this text:

"Datenschutzanfragen
*Es ist möglich, dass Sie einige Zeit nach Ihrem Widerspruch bei uns noch Werbeschreiben unserer Kunden erhalten, die sich zum heutigen Zeitpunkt beispielweise bereits im Druck oder Versand befinden."

It's obviously not a form that can be submitted to Acxiom, therefore I think that this guide should only direct users to the straightforward opt-out method that should work (the email method).

Also, the link "https://isapps.acxiom.com/optout/" redirects immediately to "https://www.acxiom.com/optout/".