### PR TITLE
Update README.md - TruePeopleSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Look for [your data](https://www.spyfly.com). Then, [opt out](https://www.spyfly
 Follow the [removal instructions](https://www.truepeoplesearch.com/removal). You will need to enter your  name, city and state, and email address, and then you’ll need to solve several captchas to see if you are listed, after which you can remove your information.
 
 ### TruePeopleSearch.net
-First, look for your information at [https://truepeoplesearch.net/search](https://truepeoplesearch.net/search). Make sure to close any additional pages the site opens, and do not click on any of the “top rated background search services” links. If your information shows up, opt out by entering the URL and other information [into this form](https://docs.google.com/forms/d/e/1FAIpQLSeCPggzv4iXE20iUjcr6vdVWxBOblCyGwDLcO-jZA5j2YF5fQ/viewform). 
+First, look for your [information](https://truepeoplesearch.net). Make sure to close any additional pages the site opens, and do not click on any of the “top rated background search services” links. If your information shows up, opt out by entering the URL and other information [into this form](https://docs.google.com/forms/d/e/1FAIpQLSeCPggzv4iXE20iUjcr6vdVWxBOblCyGwDLcO-jZA5j2YF5fQ/viewform). 
 
 ### United States Phone Book
 Search for [your information](https://www.unitedstatesphonebook.com/search.php).


### PR DESCRIPTION
https://truepeoplesearch.net/search gives an nginx web site error.  The domain name without a path works for searching.